### PR TITLE
Fix small mistakes

### DIFF
--- a/source/finalizing.c
+++ b/source/finalizing.c
@@ -25,7 +25,7 @@ void finalising_passenger(transition_system *t) {
     {
         p  = t->passengers[i];
         P_L = p.location;
-        if (P_L == floor(p.destination/t->seats_per_row) && p.carry_on == 0 && p.wait_time == 0 && p.interference_flag == 1){
+        if (p.finish == 0 && P_L == floor(p.destination/t->seats_per_row) && p.carry_on == 0 && p.wait_time == 0 && p.interference_flag == 1){
             t->passengers[i].finish = 1;
         }
     }

--- a/source/finalizing.c
+++ b/source/finalizing.c
@@ -25,7 +25,7 @@ void finalising_passenger(transition_system *t) {
     {
         p  = t->passengers[i];
         P_L = p.location;
-        if (P_L == floor(p.destination/6) && p.carry_on == 0 && p.wait_time == 0 && p.interference_flag == 1){
+        if (P_L == floor(p.destination/t->seats_per_row) && p.carry_on == 0 && p.wait_time == 0 && p.interference_flag == 1){
             t->passengers[i].finish = 1;
         }
     }

--- a/source/movement.c
+++ b/source/movement.c
@@ -22,7 +22,7 @@ void movement (transition_system *t) {
         P_S = t->passengers[i].spotting;
         P_SL = (P_S != NULL) ? t->passengers[i].spotting->location : -1;
 
-        dir = (floor(P_D / 6) - P_L) / abs(floor(P_D / 6) - P_L); /* direction; positive is right, negative is left */
+        dir = (floor(P_D / t->seats_per_row) - P_L) != 0 ? (floor(P_D / t->seats_per_row) - P_L) / abs(floor(P_D / t->seats_per_row) - P_L) : 0; /* direction; positive is right, negative is left */
 
         if (P_L > -1) {
             

--- a/tests/all_tests.c
+++ b/tests/all_tests.c
@@ -21,6 +21,7 @@ int runalltest(void)
     CuSuiteAddSuite(suite, get_example_suit());
     CuSuiteAddSuite(suite, get_initialization_suit());
     CuSuiteAddSuite(suite, get_generator_suit());
+    CuSuiteAddSuite(suite, get_finished_suit());
     CuSuiteAddSuite(suite, get_finalizing_suit());
     CuSuiteAddSuite(suite, get_rear_suit());
     CuSuiteAddSuite(suite, get_movement_suit());

--- a/tests/finalizing_tests.c
+++ b/tests/finalizing_tests.c
@@ -13,6 +13,7 @@ void finalizingtest_first(CuTest *tc) {
 
     t.length = 1;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = -1;
@@ -40,7 +41,7 @@ void finalizingtest_second(CuTest *tc) {
     transition_system t;
     t.length = 1;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
-
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = 0;
@@ -66,9 +67,8 @@ void finalizingtest_third(CuTest *tc) {
     transition_system t;
 
     t.length = 1;
-
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
-
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = 0;
@@ -92,9 +92,8 @@ void finalizingtest_fourth(CuTest *tc) {
     transition_system t;
 
     t.length = 1;
-
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
-
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = 0;
@@ -120,7 +119,8 @@ void finalizingtest_fifth(CuTest *tc) {
 
     t.length = 1;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
-
+    t.seats_per_row = 6;
+    
     p1.destination = 54;
     p1.location = 9;
     p1.finish = 0;
@@ -144,9 +144,9 @@ void finalizingtest_sixth(CuTest *tc) {
     transition_system t;
 
     t.length = 1;
-
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
-
+    t.seats_per_row = 6;
+    
     p1.destination = 54;
     p1.location = 2;
     p1.finish = 0;
@@ -167,8 +167,8 @@ void finalizingtest_seventh(CuTest *tc) {
     transition_system t;
 
     t.length = 1;
-
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 13;
     p1.location = 2;
@@ -196,7 +196,7 @@ void finalizingtest_eight(CuTest *tc) {
     t.length = 2;
 
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
-
+    t.seats_per_row = 6;    
 
     p1.destination = 13;
     p1.location = 2;

--- a/tests/is_finished_tests.c
+++ b/tests/is_finished_tests.c
@@ -12,17 +12,20 @@ void test_finished_first(CuTest *tc) {
     transition_system t;
     int finished = 0;
 
+    t.length = 2;
+    t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+
     p1.finish = 0;
     example.finish = 0;
 
     t.passengers[0] = p1;
     t.passengers[1] = example;
 
-    t.length = 2;
-
     finished = is_finished(&t);
 
     CuAssertTrue(tc, finished == 0);
+
+    free(t.passengers);
 }
 
 /* if one passenger is finished */
@@ -32,17 +35,20 @@ void test_finished_second(CuTest *tc) {
     transition_system t;
     int finished = 0;
 
+    t.length = 2;
+    t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+
     p1.finish = 1;
     example.finish = 0;
 
     t.passengers[0] = p1;
     t.passengers[1] = example;
 
-    t.length = 2;
-
     finished = is_finished(&t);
 
     CuAssertTrue(tc, finished == 0);
+
+    free(t.passengers);
 }
 
 /* if one passenger is not finished */
@@ -53,6 +59,9 @@ void test_finished_third(CuTest *tc) {
     transition_system t;
     int finished = 0;
 
+    t.length = 3;
+    t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+
     p1.finish = 1;
     p2.finish = 1;
     example.finish = 0;
@@ -61,11 +70,11 @@ void test_finished_third(CuTest *tc) {
     t.passengers[1] = example;
     t.passengers[2] = p2;
 
-    t.length = 3;
-
     finished = is_finished(&t);
 
     CuAssertTrue(tc, finished == 0);
+
+    free(t.passengers);
 }
 
 /* if one passenger finish is wrong */
@@ -76,6 +85,9 @@ void test_finished_fourth(CuTest *tc) {
     transition_system t;
     int finished = 0;
 
+    t.length = 3;
+    t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+
     p1.finish = 1;
     p2.finish = -4;
     example.finish = 0;
@@ -84,11 +96,11 @@ void test_finished_fourth(CuTest *tc) {
     t.passengers[1] = example;
     t.passengers[2] = p2;
 
-    t.length = 3;
-
     finished = is_finished(&t);
 
     CuAssertTrue(tc, finished == 0);
+
+    free(t.passengers);
 }
 
 /* if all passengers are finished */
@@ -97,7 +109,11 @@ void test_finished_fifth(CuTest *tc) {
     passenger p1;
     passenger p2;
     transition_system t;
+
     int finished = 0;
+
+    t.length = 3;
+    t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
 
     p1.finish = 1;
     p2.finish = 1;
@@ -107,11 +123,11 @@ void test_finished_fifth(CuTest *tc) {
     t.passengers[1] = example;
     t.passengers[2] = p2;
 
-    t.length = 3;
-
     finished = is_finished(&t);
 
     CuAssertTrue(tc, finished == 1);
+
+    free(t.passengers);
 }
 
 CuSuite *get_finished_suit(void) /*Dette skal op i toppen af alltests.c*/

--- a/tests/movement_tests.c
+++ b/tests/movement_tests.c
@@ -12,6 +12,7 @@ void test_outside_plane(CuTest *tc){
     transition_system t;
     t.length = 2;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = -1;
@@ -42,6 +43,7 @@ void test_in_and_out(CuTest *tc){
     transition_system t;
     t.length = 2;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = -1;
@@ -71,6 +73,7 @@ void test_in_front_of(CuTest *tc){
     transition_system t;
     t.length = 2;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = 4;
@@ -100,6 +103,7 @@ void test_different_direction(CuTest *tc){
     transition_system t;
     t.length = 2;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 6;
     p1.location = 10;
@@ -129,6 +133,7 @@ void test_one_direction(CuTest *tc){
     transition_system t;
     t.length = 2;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 54;
     p1.location = 2;
@@ -158,6 +163,8 @@ void test_location_wrong(CuTest *tc){
     transition_system t;
     t.length = 1;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
+
     p1.destination = 54;
     p1.location = -5;
     p1.finish = 0;
@@ -180,6 +187,7 @@ void test_multiple_passengers(CuTest *tc){
     transition_system t;
     t.length = 3;
     t.passengers = (passenger*)calloc(t.length, sizeof(passenger));
+    t.seats_per_row = 6;
 
     p1.destination = 50;
     p1.location = 5;


### PR DESCRIPTION
Fix the test suit for is_finished in order to actually test the function

Update movement.c and finalizing.c to not have hardcoded values for seats_per_row. 
    Because of this change, it was needed to update the corresponding tests to ensure that t.seats_per_row was set.

Added a check in finalizing.c of whether or not a passenger had already been finished in order to not keep updating them.